### PR TITLE
deploy longhorn bot automatically

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
     - master
     event:
     - pull_request
-    
+
 - name: "publish github-bot"
   image: plugins/docker
   settings:
@@ -64,7 +64,7 @@ volumes:
 
 ---
 kind: pipeline
-name: longhorn-bot-
+name: longhorn-github-runner-authorizer
 
 platform:
   os: linux
@@ -120,6 +120,40 @@ steps:
     - master
     event:
     - push
+---
+kind: pipeline
+name: deploy-longhorn-bot-images
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: deploy
+  image: alpine:latest
+  commands:
+  - apk update
+  - apk add curl
+  - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+  - chmod +x ./kubectl
+  - mv ./kubectl /usr/local/bin/kubectl
+  - kubectl rollout restart deployment -n github-bot github-bot --token=${TOKEN} --server=${API_SERVER_ARRD} --insecure-skip-tls-verify
+  - kubectl rollout restart deployment -n github-runner github-runner-authorizer --token=${TOKEN} --server=${API_SERVER_ARRD} --insecure-skip-tls-verify
+  environment:
+    TOKEN:
+        from_secret: token
+    API_SERVER_ARRD:
+        from_secret: api_server_addr
+  when:
+    instance:
+    - drone-publish.longhorn.io
+    branch:
+    - master
+    event:
+    - push
+depends_on:
+- longhorn-bot
+- longhorn-github-runner-authorizer
 
 
 volumes:

--- a/service-account/github-bot.yaml
+++ b/service-account/github-bot.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-bot-service-account
+  namespace: github-bot
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-bot-role
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: longhorn-bot-binding
+  namespace: github-bot
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-bot-role
+subjects:
+- kind: ServiceAccount
+  name: longhorn-bot-service-account
+  namespace: github-bot
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: longhorn-runner-binding
+  namespace: github-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-bot-role
+subjects:
+- kind: ServiceAccount
+  name: longhorn-bot-service-account
+  namespace: github-bot


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/1695

This PR will utilize drone to redeploy `github-bot` and `github-runner-authorizer` deployments after image has been pushed to docker hub.

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@rancher.com>