### PR TITLE
ci: fix github-bot ImportError: cannot import name 'escape' from 'jinja2'

### DIFF
--- a/github-bot/requirements.txt
+++ b/github-bot/requirements.txt
@@ -1,5 +1,8 @@
 Everett==1.0.2
 Flask==1.1.2
+Jinja2==3.0.3
+werkzeug==2.0.2
+itsdangerous==2.0.1
 Flask-HTTPAuth==4.1.0
 Gunicorn==20.0.4
 PyGitHub==1.51


### PR DESCRIPTION
ci: fix github-bot ImportError: cannot import name 'escape' from 'jinja2'

For https://github.com/longhorn/longhorn/issues/4607

Signed-off-by: Yang Chiu <yang.chiu@suse.com>