### PR TITLE
fix: revert werkzeug version

### DIFF
--- a/github-bot/requirements.txt
+++ b/github-bot/requirements.txt
@@ -1,7 +1,7 @@
 Everett==1.0.2
 Flask==1.1.2
 Jinja2==3.0.3
-werkzeug==3.0.3
+werkzeug==2.0.2
 itsdangerous==2.0.1
 Flask-HTTPAuth==4.1.0
 Gunicorn==20.0.4


### PR DESCRIPTION
fix: revert werkzeug version

revert werkzeug version to fix:
```
from .app import Flask
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 32, in <module>
    from werkzeug.wrappers import BaseResponse
ImportError: cannot import name 'BaseResponse' from 'werkzeug.wrappers' (/usr/local/lib/python3.10/site-packages/werkzeug/wrappers/__init__.py)
```

Signed-off-by: Yang Chiu <yang.chiu@suse.com>