### PR TITLE
chore(template): cleanup pre ready-for-testing checklist

### DIFF
--- a/github-bot/longhorn_github_bot/templates/pre-merge.md
+++ b/github-bot/longhorn_github_bot/templates/pre-merge.md
@@ -1,43 +1,32 @@
 
 ## Pre Ready-For-Testing Checklist
-* [ ] Where is the reproduce steps/test steps documented?
-The reproduce steps/test steps are at:
+* [ ] **Context & Reproduction**
+    Where are the reproduction or test steps documented?
+    Link:
 
-* [ ] Is there a workaround for the issue? If so, where is it documented?
-The workaround is at:
+* [ ] **Workaround**
+    Is there a workaround for the issue? If yes, where is it documented?
+    Link:
 
-* [ ] Does the PR include the explanation for the fix or the feature?
+* [ ] **Fix / Feature Explanation**
+    Does the PR include a clear explanation of the fix or the new feature?
 
-* [ ] Does the PR include deployment change (YAML/Chart)? If so, where are the PRs for both YAML file and Chart?
-The PR for the YAML change is at:
-The PR for the chart change is at:
+* [ ] **Backend Code Changes**
+    Have all required backend changes been merged (e.g., Manager, Engine, Instance Manager, BackupStore)?
+    PR(s):
 
-* [ ] Have the backend code been merged (Manager, Engine, Instance Manager, BackupStore etc) (including `backport-needed/*`)?
-The PR is at
+* [ ] **Deployment Changes (YAML / Helm Chart)**
+    Does the PR introduce any deployment changes?
+    PR:
 
-* [ ] Which areas/issues this PR might have potential impacts on?
-Area
-Issues
+* [ ] **Longhorn Enhancement Proposal (LEP)** *(if labeled `require/LEP`)*
+    Has the LEP PR been submitted?
+    PR:
 
-* [ ] **If labeled: require/LEP** Has the Longhorn Enhancement Proposal PR submitted?
-The LEP PR is at
+* [ ] **Documentation Updates** *(if labeled `require/doc`)*
+    Has the required documentation PR been submitted or merged?
+    PR:
 
-* [ ] **If labeled: area/ui** Has the UI issue filed or ready to be merged (including `backport-needed/*`)?
-The UI issue/PR is at
-
-* [ ] **If labeled: require/doc** Has the necessary document PR submitted or merged (including `backport-needed/*`)?
-The documentation issue/PR is at
-
-* [ ] **If labeled: require/automation-e2e** Has the end-to-end test plan been merged? Have QAs agreed on the automation test case? If only test case skeleton w/o implementation, have you created an implementation issue (including `backport-needed/*`)
-The automation skeleton PR is at
-The automation test case PR is at 
-The issue of automation test case implementation is at (please create by [the template](https://github.com/longhorn/longhorn/issues/new?assignees=&labels=area%2Ftest&template=test.md&title=%5BTEST%5D))
-
-* [ ] **If labeled: require/automation-engine** Has the engine integration test been merged (including `backport-needed/*`)?
-The engine automation PR is at
-
-* [ ] **If labeled: require/manual-test-plan** Has the manual test plan been documented?
-The updated manual test plan is at
-
-* [ ] **If the fix introduces the code for backward compatibility** Has a separate issue been filed with the label `release/obsolete-compatibility`?
-The compatibility issue is filed at
+* [ ] **Manual Test Plan** *(if labeled `require/manual-test-plan`)*
+    Has the manual test plan been documented?
+    Link:


### PR DESCRIPTION
The pre-merge checklist is outdated. Cleaning up items that are no longer useful.