### PR TITLE
ci: fix broken dependency for github-runner-authorizer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - build-github-bot-image
-    - build-github-runner-authorizer-image
     steps:
     - name: Rollout restart github-bot
       uses: actions-hub/kubectl@v1.30.0


### PR DESCRIPTION
ci: fix broken dependency for github-runner-authorizer

Signed-off-by: Yang Chiu <yang.chiu@suse.com>